### PR TITLE
5 bug in format csv date time at midnight

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BuzzardsBay
 Type: Package
 Title: Process and analyze data for the COMBB project
-Version: 0.1.0.9015
+Version: 0.1.0.9016
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BuzzardsBay 0.1.0.9016
+
+Fixed bug in `format_csv_date_time()` that caused it to drop the time component
+at midnight.  E.g. "8/7/2024 0:00" became "2024-08-07".  
+
 # BuzzardsBay 0.1.0.9015
 
 ### CSV Import

--- a/R/format_csv_date.R
+++ b/R/format_csv_date.R
@@ -81,6 +81,6 @@ format_csv_date_time <- function(x, format = "datetime") {
   if (format == "datetime")
     return(dates)
   if (format == "character")
-    return(as.character(dates))
+    return(format(dates, format = "%Y-%m-%d %T"))
   stop("Unrecognized format argument")
 }

--- a/tests/testthat/test-format_csv_date.R
+++ b/tests/testthat/test-format_csv_date.R
@@ -1,0 +1,14 @@
+test_that("format_csv_date_time() works at midnight", {
+  x <- c('8/6/2024 23:50', '8/7/2024 0:00', '8/7/2024 0:10', '8/7/2024 0:20')
+
+
+  result <- format_csv_date_time(x, format = 'character')
+  expected_result <- c("2024-08-06 23:50:00",
+                       "2024-08-07 00:00:00",
+                       "2024-08-07 00:10:00",
+                       "2024-08-07 00:20:00")
+
+  expect_equal(result, expected_result)
+
+
+})

--- a/tests/testthat/test-format_csv_date.R
+++ b/tests/testthat/test-format_csv_date.R
@@ -1,8 +1,8 @@
-test_that("format_csv_date_time() works at midnight", {
-  x <- c('8/6/2024 23:50', '8/7/2024 0:00', '8/7/2024 0:10', '8/7/2024 0:20')
+test_that("format_csv_date_time( ) works at midnight with character output", {
+  x <- c("8/6/2024 23:50", "8/7/2024 0:00", "8/7/2024 0:10", "8/7/2024 0:20")
 
 
-  result <- format_csv_date_time(x, format = 'character')
+  result <- format_csv_date_time(x, format = "character")
   expected_result <- c("2024-08-06 23:50:00",
                        "2024-08-07 00:00:00",
                        "2024-08-07 00:10:00",
@@ -10,5 +10,8 @@ test_that("format_csv_date_time() works at midnight", {
 
   expect_equal(result, expected_result)
 
+  # test with other input format
+  result2 <-  format_csv_date_time(result, format = "character")
+  expect_equal(result2, expected_result)
 
 })


### PR DESCRIPTION
Times are no longer dropped at midnight by `format_csv_date_time(x, format = "character")`.  