### PR TITLE
Fix bug in check_salinity()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BuzzardsBay
 Type: Package
 Title: Process and analyze data for the COMBB project
-Version: 0.1.0.9017
+Version: 0.1.0.9018
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# BuzzardsBay 0.1.0.9018
+
+* Fixed bug in Salinity check that could cause 
+  the low variation in salinity flag (`Slv`) to overwrite or duplicate 
+  other salinity flags.
+  This bug was first detected in the MX801 import but 
+  has been present for all previously run QAQC. 
+  It only affects salinity, and only in rows 
+  where low variation in salinity is detected. 
+  The low variation flag should always be correct but 
+  other salinity flags might be either dropped or erroneously show up 
+  along with the low variation in salinity flag. 
+  Non-salinity flags were not affected. 
+  
+* Suppressed confusing chatter from `readxls::read_excel()` that showed up when
+  calling `qc_deployment()` on output from MX801 logger.
+  
+* Updated test for MX801 logger output. 
+  
+  
 # BuzzardsBay 0.1.0.9017
 
 * Documentation edits

--- a/R/checks.R
+++ b/R/checks.R
@@ -131,7 +131,7 @@ check_salinity <- function(x, interval = 15, site, sites) {
   #----------------------------------------------------------------------------#
   flag <- rep("", length(x))
   flag[big_jump] <- paste0(flag[big_jump], "Sj:")
-  flag[low_var] <- paste0(flag[big_jump], "Slv:")
+  flag[low_var] <- paste0(flag[low_var], "Slv:")
   flag[low_for_site] <- paste0(flag[low_for_site], "Ssl:")
   flag[high_for_site] <- paste0(flag[high_for_site], "Ssh:")
 

--- a/R/parse_mx801_details.R
+++ b/R/parse_mx801_details.R
@@ -51,9 +51,9 @@ parse_mx801_details <- function(file) {
   # Delete all but the last colon on every line.
   # And convert to a list with read_yaml()
 
-
-  d <- readxl::read_excel(file, sheet = 3, col_types = "text",
-                          col_names = FALSE)
+  suppressMessages( # Suppress New Names message
+    d <- readxl::read_excel(file, sheet = 3, col_types = "text", # nolint
+                            col_names = FALSE))
   d2 <- lapply(d, function(x) paste0(x, ":")) |> as.data.frame()
 
   restore_na <- function(x) {
@@ -249,7 +249,6 @@ parse_mx801_details <- function(file) {
   cc$measured_cond <- numeric(0)
   cc$temperature <- numeric(0)
   for (i in calibration_pt_i) {
-    cat(i, "\n")
     cp <- cond$Channel_Parameters[[i]]
     cc$spec_cond_25c <- c(cc$spec_cond_25c,
                           cp$Specific_Conductance_at_25C |> extract_number())

--- a/tests/testthat/test-qc_deployment.R
+++ b/tests/testthat/test-qc_deployment.R
@@ -31,7 +31,7 @@ test_that("qc_deployment() works with repeated High Range in column name", {
   # "High Range" in the name.
   # The .csv header line looks like this:
   # Date Time,High Range High Range (μS/cm),
-  # Temp (°C)  #21095959,Specific Conductance (μS/cm),Salinity (ppt)
+  # Temp (°C)  #21095959,Specific Conductance (μS/cm),Salinity (ppt) # nolint
 
   paths <- local_example_dir(site_filter = "BD1",
                              deployment_filter = "2024-06-21")
@@ -199,9 +199,8 @@ test_that("man/qc_deployment() works with MX801 data", {
   #  Input file with different internal line endings
   #----------------------------------------------------------------------------#
   skip("Skipping extra MX801 test - always skipped.")
-
   paths4 <-  lookup_paths(deployment_dir = deployment_dirs[4])
-  expect_no_error(res4 <- qc_deployment(paths3$deployment_dir))
+  expect_no_error(res4 <- qc_deployment(paths4$deployment_dir))
 
 
 })


### PR DESCRIPTION
Fix bug that caused the presence of the Slv (low variation in salinity) flag to erase or erroneously add other salinity flags.  Slv was always correct and other salinity flags were only affected on rows with the Slv flag.