### PR TITLE
Tinytex woes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BuzzardsBay
 Type: Package
 Title: Process and analyze data for the COMBB project
-Version: 1.0.0.9003
+Version: 1.0.0.9004
 Authors@R: 
     c(person("Ethan", "Plunkett",  email = "plunkett@umass.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4405-2251")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BuzzardsBay 1.0.0.9004
+
+- Bug fix: When producing report PDF, Pandoc choked on long names in path, effectively breaking it for
+  users with long last names.
+
 # BuzzardsBay 1.0.0.9003
 
 * Document Tide Rider example data.  [#29](https://github.com/UMassCDS/BuzzardsBay/issues/29)

--- a/R/report_site.R
+++ b/R/report_site.R
@@ -124,8 +124,7 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
    template <- system.file('rmd/seasonal_report.rmd', package = 'BuzzardsBay', mustWork = TRUE)
    report_file <- file.path(site_dir, 'combined', paste0('report_', site, '_', year, '.pdf'))
    abs_report_file <- file.path(normalizePath(file.path(site_dir, 'combined')), paste0('report_', site, '_', year, '.pdf'))
-   temp_report_file <- file.path(tempdir(), basename(abs_report_file))
-
+   temp_report_file <- file.path(normalizePath(tempdir(), winslash = '/'), basename(abs_report_file))
 
    long_site <- get_site_name(site_dir)
    title <- paste0(long_site, ' (', site, ') in ', year)
@@ -149,7 +148,9 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
    # Writing to local temp file and then copying to final location to avoid
    # weird OneDrive issues  see #24
    rmarkdown::render(input = template, output_file = temp_report_file,                     # write PDF (have to use absolute path here 😡)
-                     params = pars, quiet = FALSE)
+                     params = pars, quiet = FALSE, output_options = list(keep_tex = TRUE))
+
+   stop()
 
    message('Report rendered. Copying report file...')
    file.copy(temp_report_file, abs_report_file)

--- a/R/report_site.R
+++ b/R/report_site.R
@@ -139,11 +139,19 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
 
    pars <- list(title = title, date = date, stat = seasonal$stat, value = seasonal$value)
 
+   message('===== Report diagnostics =====')
+   message('template = ', template)
+   message('report_file = ', report_file)
+   message('abs_report_file = ', abs_report_file)
+   message('temp_report_file = ', temp_report_file)
+
+   message('Rendering report...')
    # Writing to local temp file and then copying to final location to avoid
    # weird OneDrive issues  see #24
    rmarkdown::render(input = template, output_file = temp_report_file,                     # write PDF (have to use absolute path here 😡)
                      params = pars, quiet = TRUE)
 
+   message('Report rendered. Copying report file...')
    file.copy(temp_report_file, abs_report_file)
    file.remove(temp_report_file)
 

--- a/R/report_site.R
+++ b/R/report_site.R
@@ -36,6 +36,8 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
 
    max_interp <- 10                                                                       # max distance for Baywatchers interpolation (min)
 
+
+
    if(check) {
       if(!check_site(site_dir, check_report = FALSE, check_baywatchers = baywatchers))
          stop('check_site failed. Address the issues or rerun report_site with check = FALSE.')
@@ -141,20 +143,13 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
    long_tmp <- normalizePath(tempdir(), winslash = '/')                                   # Force long temp path for this R session to prevent Win 8.3 paths
    Sys.setenv(TMPDIR = long_tmp, TMP = long_tmp, TEMP = long_tmp)
 
-   message('===== Report diagnostics =====')
-   message('template = ', template)
-   message('report_file = ', report_file)
-   message('abs_report_file = ', abs_report_file)
-   message('temp_report_file = ', temp_report_file)
 
-   message('Rendering report...')
-   # Writing to local temp file and then copying to final location to avoid
-   # weird OneDrive issues  see #24
+   msg('Rendering report...')
+   # Writing to local temp file and then copying to final location to avoid weird OneDrive issues  see #24
    rmarkdown::render(input = template, output_file = temp_report_file,                     # write PDF (have to use absolute path here 😡)
-                     params = pars, quiet = FALSE, output_options = list(keep_tex = TRUE))
+                     params = pars, quiet = TRUE, output_options = list(keep_tex = FALSE))
 
 
-   message('Report rendered. Copying report file...')
    file.copy(temp_report_file, abs_report_file)
    file.remove(temp_report_file)
 

--- a/R/report_site.R
+++ b/R/report_site.R
@@ -149,7 +149,7 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
    # Writing to local temp file and then copying to final location to avoid
    # weird OneDrive issues  see #24
    rmarkdown::render(input = template, output_file = temp_report_file,                     # write PDF (have to use absolute path here 😡)
-                     params = pars, quiet = TRUE)
+                     params = pars, quiet = FALSE)
 
    message('Report rendered. Copying report file...')
    file.copy(temp_report_file, abs_report_file)

--- a/R/report_site.R
+++ b/R/report_site.R
@@ -138,6 +138,9 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
 
    pars <- list(title = title, date = date, stat = seasonal$stat, value = seasonal$value)
 
+   long_tmp <- normalizePath(tempdir(), winslash = '/')                                   # Force long temp path for this R session to prevent Win 8.3 paths
+   Sys.setenv(TMPDIR = long_tmp, TMP = long_tmp, TEMP = long_tmp)
+
    message('===== Report diagnostics =====')
    message('template = ', template)
    message('report_file = ', report_file)
@@ -150,7 +153,6 @@ report_site <- function(site_dir, check = TRUE, baywatchers = TRUE, salinity = T
    rmarkdown::render(input = template, output_file = temp_report_file,                     # write PDF (have to use absolute path here 😡)
                      params = pars, quiet = FALSE, output_options = list(keep_tex = TRUE))
 
-   stop()
 
    message('Report rendered. Copying report file...')
    file.copy(temp_report_file, abs_report_file)

--- a/inst/scripts/tiny_tex_diagnostic.R
+++ b/inst/scripts/tiny_tex_diagnostic.R
@@ -1,0 +1,53 @@
+# Run this in R and send me ALL the output
+
+
+# base_name <- 'report_AB2_2024'      # Brad's version
+base_name <- 'report_JMS4_2025'    # Lilia's version
+
+options(tinytex.verbose = TRUE)
+
+# 1. Check TinyTeX installation
+message("--- TinyTeX info ---")
+message("TinyTeX installed: ", tinytex::is_tinytex())
+message("pdflatex path: ", Sys.which("pdflatex"))
+message("TinyTeX root: ", tinytex::tinytex_root())
+
+# 2. Try compiling the .tex file that was left behind
+tex_file <- file.path(tempdir(), paste0(base_name, ".tex"))
+if (file.exists(tex_file)) {
+   message("--- Compiling leftover .tex file ---")
+   tryCatch(
+      tinytex::pdflatex(tex_file),
+      error = function(e) message("pdflatex error: ", e$message)
+   )
+} else {
+   message("No leftover .tex file found. Re-rendering...")
+   # Re-render to generate it, then check the log
+   tryCatch(
+      rmarkdown::render(
+         input = system.file('rmd/seasonal_report.rmd', package = 'BuzzardsBay', mustWork = TRUE),
+         output_file = file.path(tempdir(), paste0(base_name, ".pdf")),
+         params = list(title = "test", date = "test",
+                       stat = NULL, value = NULL),
+         quiet = FALSE
+      ),
+      error = function(e) message("Render error: ", e$message)
+   )
+   tex_file <- file.path(tempdir(), base_name(base_name, ".tex"))
+}
+
+# 3. Grab the .log file — this is what actually matters
+log_file <- sub("\\.tex$", ".log", tex_file)
+if (file.exists(log_file)) {
+   message("--- LaTeX log (last 80 lines) ---")
+   log_lines <- readLines(log_file)
+   cat(tail(log_lines, 80), sep = "\n")
+} else {
+   message("No .log file found at: ", log_file)
+}
+
+# 4. Check what LaTeX packages are installed
+message("--- Installed LaTeX packages (first 30) ---")
+pkgs <- tinytex::tl_pkgs()
+message(length(pkgs), " packages installed")
+cat(head(pkgs, 30), sep = "\n")


### PR DESCRIPTION
Fixes crash in pandoc caused by names in path longer than 8 characters, as win 8.3 names include tilde that broke pandoc. Code now works for users with long last names!